### PR TITLE
chore(release): 0.4.0 - bump indexmap crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "import_map"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "idna"
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "import_map"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "indexmap",
  "log",
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "import_map"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["the Deno authors"]
 edition = "2018"
 license = "MIT"
@@ -14,8 +14,7 @@ exclude = [
 ]
 
 [dependencies]
-# TODO(bartlomieju): unlock when https://github.com/tkaitchuck/aHash/issues/95 is resolved
-indexmap = { version = "=1.6.2", features = ["serde"] }
+indexmap = { version = "1.7.0", features = ["serde"] }
 log = { version = "0.4.14" }
 serde = { version = "1.0.129", features = ["derive"] }
 serde_json = { version = "1.0.66", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "import_map"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["the Deno authors"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
The only dependency of this crate is deno. Seems to compile ok when bumping to 1.7.0.

This is for https://github.com/denoland/deno_ast/issues/37