### PR TITLE
feat: use Url for the base specifier instead of str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "import_map"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "import_map"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["the Deno authors"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
When I went to go integrate this into Deno, I found that there was some extra complexity we were doing by converting back and forth between `Url` and `str`. It's easier to just use `Url` for the base here.