### PR TITLE
feat: add .imports_keys() method to ImportMap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,11 @@ pub struct ImportMapWithDiagnostics {
 }
 
 impl ImportMap {
+  /// Provide the keys of the `imports` property of the import map.
+  pub fn imports_keys(&self) -> Vec<&str> {
+    self.imports.keys().map(|k| k.as_str()).collect()
+  }
+
   pub fn resolve(
     &self,
     specifier: &str,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -392,3 +392,21 @@ fn update_imports() {
     "https://deno.land/std/node/url.ts"
   );
 }
+
+#[test]
+fn import_keys() {
+  let json_map = r#"{
+    "imports": {
+      "fs": "https://example.com/1",
+      "https://example.com/example/": "https://example.com/2/"
+    }
+  }"#;
+  let import_map =
+    parse_from_json(&Url::parse("https://deno.land").unwrap(), json_map)
+      .unwrap()
+      .import_map;
+  assert_eq!(
+    import_map.imports_keys(),
+    vec!["https://example.com/example/", "fs"]
+  );
+}


### PR DESCRIPTION
This is in support of denoland/deno#13619.