### PR TITLE
feat: expose base url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,10 @@ impl ImportMap {
     self.imports.keys().map(|k| k.as_str()).collect()
   }
 
+  pub fn base_url(&self) -> &Url {
+    &self.base_url
+  }
+
   pub fn resolve(
     &self,
     specifier: &str,


### PR DESCRIPTION
In `deno vendor` if someone provides an import map in the vendor folder, then it should be ignored (ex. someone runs `deno vendor` then does `deno vendor --import-map vendor/import_map.json`). This will matter more once we have automatic deno.json import map resolution.

Although the base url could be stored along with the import map in deno's proc state, it's much easier to just add this method here.