### PR TITLE
feat: basic manipulation and ability to write out import map to JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "import_map"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +22,22 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ctor"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "form_urlencoded"
@@ -47,6 +72,7 @@ version = "0.9.0"
 dependencies = [
  "indexmap",
  "log",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "url",
@@ -86,10 +112,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ logging = ["log"]
 default = ["logging"]
 
 [dependencies]
-indexmap = { version = "1.7.0", features = ["serde"] }
+indexmap = { version = "1.8.2", features = ["serde"] }
 log = { version = "0.4.14", optional = true }
 serde = { version = "1.0.129", features = ["derive"] }
 serde_json = { version = "1.0.66", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,5 @@ serde_json = { version = "1.0.66", features = ["preserve_order"] }
 url = { version = "2.2.2", features = ["serde"] }
 
 [dev-dependencies]
+pretty_assertions = "1.2.1"
 walkdir = "2.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "import_map"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["the Deno authors"]
 edition = "2018"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,7 +611,9 @@ fn parse_scope_map(
   let mut normalized_map: ScopesMap = ScopesMap::new();
 
   // Order is preserved because of "preserve_order" feature of "serde_json".
-  for (i, (raw_scope_prefix, potential_specifier_map)) in scope_map.into_iter().enumerate() {
+  for (i, (raw_scope_prefix, potential_specifier_map)) in
+    scope_map.into_iter().enumerate()
+  {
     let scope_prefix_url = match base_url.join(&raw_scope_prefix) {
       Ok(url) => url.to_string(),
       _ => {
@@ -626,7 +628,7 @@ fn parse_scope_map(
     let norm_map =
       parse_specifier_map(potential_specifier_map, base_url, diagnostics);
 
-      let value = ScopesMapValue {
+    let value = ScopesMapValue {
       index: i,
       raw_key: if scope_prefix_url == raw_scope_prefix {
         None
@@ -634,9 +636,9 @@ fn parse_scope_map(
         // only store this if they differ to save memory
         Some(raw_scope_prefix)
       },
-      imports:  norm_map,
+      imports: norm_map,
     };
-    normalized_map.insert(scope_prefix_url,value );
+    normalized_map.insert(scope_prefix_url, value);
   }
 
   // Sort in longest and alphabetical order.
@@ -740,8 +742,11 @@ fn resolve_scopes_match(
 ) -> Result<Option<Url>, ImportMapError> {
   // exact-match
   if let Some(scope_imports) = scopes.get(referrer) {
-    let scope_match =
-      resolve_imports_match(&scope_imports.imports, normalized_specifier, as_url)?;
+    let scope_match = resolve_imports_match(
+      &scope_imports.imports,
+      normalized_specifier,
+      as_url,
+    )?;
     // Return only if there was actual match (not None).
     if scope_match.is_some() {
       return Ok(scope_match);
@@ -752,8 +757,11 @@ fn resolve_scopes_match(
     if normalized_scope_key.ends_with('/')
       && referrer.starts_with(normalized_scope_key)
     {
-      let scope_match =
-        resolve_imports_match(&scope_imports.imports, normalized_specifier, as_url)?;
+      let scope_match = resolve_imports_match(
+        &scope_imports.imports,
+        normalized_specifier,
+        as_url,
+      )?;
       // Return only if there was actual match (not None).
       if scope_match.is_some() {
         return Ok(scope_match);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,9 +164,9 @@ impl ImportMap {
     Ok(diagnostics)
   }
 
-  /// Removes any imports or scopes referencing the provided path in
+  /// Removes any imports or scopes referencing the provided folder in
   /// the import map.
-  pub fn with_stripped_path(&self, path: &Url) -> Self {
+  pub fn with_stripped_folder(&self, folder: &Url) -> Self {
     fn filter_imports(imports: &SpecifierMap, path: &Url) -> SpecifierMap {
       imports
         .iter()
@@ -182,18 +182,18 @@ impl ImportMap {
     }
 
     let base_url = self.base_url().to_owned();
-    let imports = filter_imports(&self.imports, path);
+    let imports = filter_imports(&self.imports, folder);
     let scopes = self
       .scopes
       .iter()
       .filter_map(|(key, imports)| {
         if let Ok(base) = base_url.join(key) {
-          if base.as_str().starts_with(&path.as_str()) {
+          if base.as_str().starts_with(&folder.as_str()) {
             return None;
           }
         }
         // now filter out any entries
-        let imports = filter_imports(imports, path);
+        let imports = filter_imports(imports, folder);
         if imports.is_empty() {
           None
         } else {
@@ -662,7 +662,7 @@ mod test {
   }
 
   #[test]
-  pub fn strips_path_from_import_map() {
+  pub fn strips_folder_from_import_map() {
     let import_map = parse_from_json(
       &Url::parse("file:///dir/").unwrap(),
       r#"{
@@ -689,7 +689,7 @@ mod test {
     .unwrap()
     .import_map;
     let new_import_map = import_map
-      .with_stripped_path(&Url::parse("file:///dir/vendor/").unwrap());
+      .with_stripped_folder(&Url::parse("file:///dir/vendor/").unwrap());
     assert_eq!(new_import_map.base_url(), import_map.base_url());
     assert_eq!(
       new_import_map.imports,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,17 @@ pub struct ImportMap {
 }
 
 impl ImportMap {
+  pub fn new(base_url: Url) -> Self {
+    Self {
+      base_url: base_url.clone(),
+      imports: SpecifierMap {
+        base_url,
+        inner: Default::default(),
+      },
+      scopes: Default::default(),
+    }
+  }
+
   pub fn base_url(&self) -> &Url {
     &self.base_url
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ impl ImportMap {
 
   /// Removes any imports or scopes referencing the provided folder in
   /// the import map.
-  pub fn with_stripped_folder(&self, folder: &Url) -> Self {
+  pub fn with_folder_removed(&self, folder: &Url) -> Self {
     fn filter_imports(imports: &SpecifierMap, path: &Url) -> SpecifierMap {
       imports
         .iter()
@@ -689,7 +689,7 @@ mod test {
     .unwrap()
     .import_map;
     let new_import_map = import_map
-      .with_stripped_folder(&Url::parse("file:///dir/vendor/").unwrap());
+      .with_folder_removed(&Url::parse("file:///dir/vendor/").unwrap());
     assert_eq!(new_import_map.base_url(), import_map.base_url());
     assert_eq!(
       new_import_map.imports,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -417,12 +417,9 @@ pub fn outputs_import_map_as_json_empty() {
   let json = r#"{
 }
 "#;
-  let import_map = parse_from_json(
-    &Url::parse("file:///dir/").unwrap(),
-    json
-  )
-  .unwrap()
-  .import_map;
+  let import_map = parse_from_json(&Url::parse("file:///dir/").unwrap(), json)
+    .unwrap()
+    .import_map;
   assert_eq!(import_map.to_json(), json);
 }
 
@@ -434,12 +431,9 @@ pub fn outputs_import_map_as_json_imports_only() {
   }
 }
 "#;
-  let import_map = parse_from_json(
-    &Url::parse("file:///dir/").unwrap(),
-    json
-  )
-  .unwrap()
-  .import_map;
+  let import_map = parse_from_json(&Url::parse("file:///dir/").unwrap(), json)
+    .unwrap()
+    .import_map;
   assert_eq!(import_map.to_json(), json);
 }
 
@@ -454,12 +448,9 @@ pub fn outputs_import_map_as_json_scopes_only() {
   }
 }
 "#;
-  let import_map = parse_from_json(
-    &Url::parse("file:///dir/").unwrap(),
-    json
-  )
-  .unwrap()
-  .import_map;
+  let import_map = parse_from_json(&Url::parse("file:///dir/").unwrap(), json)
+    .unwrap()
+    .import_map;
   assert_eq!(import_map.to_json(), json);
 }
 
@@ -487,12 +478,9 @@ pub fn outputs_import_map_as_json_imports_and_scopes() {
   }
 }
 "#;
-  let import_map = parse_from_json(
-    &Url::parse("file:///dir/").unwrap(),
-    json
-  )
-  .unwrap()
-  .import_map;
+  let import_map = parse_from_json(&Url::parse("file:///dir/").unwrap(), json)
+    .unwrap()
+    .import_map;
   assert_eq!(import_map.to_json(), json);
 }
 
@@ -524,11 +512,13 @@ pub fn strips_folder_from_import_map() {
   )
   .unwrap()
   .import_map;
-  let new_import_map = import_map
-    .with_folder_removed(&Url::parse("file:///dir/vendor/").unwrap());
+  let new_import_map =
+    import_map.with_folder_removed(&Url::parse("file:///dir/vendor/").unwrap());
   assert_eq!(new_import_map.base_url(), import_map.base_url());
 
-  assert_eq!(new_import_map.to_json(), r#"{
+  assert_eq!(
+    new_import_map.to_json(),
+    r#"{
   "imports": {
     "a": "./other/",
     "/~/": "./lib/"
@@ -539,5 +529,6 @@ pub fn strips_folder_from_import_map() {
     }
   }
 }
-"#);
+"#
+  );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -398,7 +398,8 @@ fn import_keys() {
   let json_map = r#"{
     "imports": {
       "fs": "https://example.com/1",
-      "https://example.com/example/": "https://example.com/2/"
+      "https://example.com/example/": "https://example.com/2/",
+      "/~/": "./lib/"
     }
   }"#;
   let import_map =
@@ -407,6 +408,6 @@ fn import_keys() {
       .import_map;
   assert_eq!(
     import_map.imports_keys(),
-    vec!["https://example.com/example/", "fs"]
+    vec!["https://example.com/example/", "https://deno.land/~/", "fs"]
   );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -404,6 +404,46 @@ fn append_imports() {
 }
 
 #[test]
+fn get_or_append_scope_mut() {
+  let mut import_map =
+    parse_from_json(&Url::parse("https://deno.land").unwrap(), "{}")
+      .unwrap()
+      .import_map;
+
+  // test adding
+  let other_scopes = import_map.get_or_append_scope_mut("/other").unwrap();
+  other_scopes
+    .append("test".to_string(), "/other/".to_string())
+    .unwrap();
+
+  // test adding with a key that will resolve to the same as the first one
+  let other_scopes = import_map
+    .get_or_append_scope_mut("https://deno.land/other")
+    .unwrap();
+  other_scopes
+    .append("second".to_string(), "/other2/".to_string())
+    .unwrap();
+
+  // now add an empty scope
+  import_map.get_or_append_scope_mut("/empty").unwrap();
+
+  assert_eq!(
+    import_map.to_json(),
+    r#"{
+  "scopes": {
+    "/other": {
+      "test": "/other/",
+      "second": "/other2/"
+    },
+    "/empty": {
+    }
+  }
+}
+"#
+  );
+}
+
+#[test]
 fn import_keys() {
   let json_map = r#"{
     "imports": {


### PR DESCRIPTION
This will be used in `deno vendor`.

Adds:

* `with_folder_removed(&self, folder: &Url) -> Self` - Ability to remove a certain folder from the import map (will use this in deno vendor to remove the output directory)
* `to_json() -> String` - Gets the import map as JSON text.
* `imports_mut().append(key, value)`
* `get_or_append_scope_mut(key)`