### PR TITLE
feat: add lookup api

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,14 @@ impl ImportMap {
     &self.base_url
   }
 
+  /// Given a specifier and a referring specifier, determine if a value in the
+  /// import map could be used as an import specifier that resolves using the
+  /// import map.
+  pub fn lookup(&self, specifier: &Url, referrer: &Url) -> Option<String> {
+    lookup_scopes(&self.scopes, specifier, referrer.as_str())
+      .or_else(|| lookup_imports(&self.imports, specifier))
+  }
+
   pub fn resolve(
     &self,
     specifier: &str,
@@ -795,6 +803,63 @@ fn append_specifier_to_base(
   } else {
     Ok(base.join(specifier)?)
   }
+}
+
+/// Attempts to match a specifier to a specifier map value, returning the
+/// optional string specifier that can be used to resolve against the import
+/// map.
+fn lookup_imports(
+  specifier_map: &SpecifierMap,
+  specifier: &Url,
+) -> Option<String> {
+  let specifier_str = specifier.to_string();
+  for (key, value) in specifier_map.inner.iter() {
+    let key = if key.starts_with("file://") {
+      key.replace("file://", "")
+    } else {
+      key.clone()
+    };
+    if let Some(address) = &value.maybe_address {
+      let address_str = address.to_string();
+      if address_str == specifier_str {
+        return Some(key);
+      }
+      if address_str.ends_with('/') && specifier_str.starts_with(&address_str) {
+        return Some(specifier_str.replace(&address_str, &key));
+      }
+    }
+  }
+  None
+}
+
+/// Attempts to iterate over scopes to identify a scope entry that matches the
+/// referrer and then attempts to lookup the specifier in the scope map,
+/// returning a string specifier that can be used to resolve the specifier via
+/// the import map.
+fn lookup_scopes(
+  scopes: &ScopesMap,
+  specifier: &Url,
+  referrer: &str,
+) -> Option<String> {
+  if let Some(scopes_map) = scopes.get(referrer) {
+    let scopes_match = lookup_imports(&scopes_map.imports, specifier);
+    if scopes_match.is_some() {
+      return scopes_match;
+    }
+  }
+
+  for (normalized_scope_key, scopes_map) in scopes.iter() {
+    if normalized_scope_key.ends_with('/')
+      && referrer.starts_with(normalized_scope_key)
+    {
+      let scopes_match = lookup_imports(&scopes_map.imports, specifier);
+      if scopes_match.is_some() {
+        return scopes_match;
+      }
+    }
+  }
+
+  None
 }
 
 fn resolve_scopes_match(


### PR DESCRIPTION
This adds a `.lookup()` API to an `ImportMap`.  This effectively "reverses" a resolution, returning a import specifier string that would resolve to the same url specifier, but via the import map.

This is part of the journey of allowing the language server to offer quick fixes and auto import completions which identify to the user a situation where an import specifier can be remapped to an import map.