### PR TITLE
fix: use raw key with lookup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -814,18 +814,14 @@ fn lookup_imports(
 ) -> Option<String> {
   let specifier_str = specifier.to_string();
   for (key, value) in specifier_map.inner.iter() {
-    let key = if key.starts_with("file://") {
-      key.replace("file://", "")
-    } else {
-      key.clone()
-    };
+    let key = value.raw_key.as_ref().unwrap_or(key);
     if let Some(address) = &value.maybe_address {
       let address_str = address.to_string();
       if address_str == specifier_str {
-        return Some(key);
+        return Some(key.clone());
       }
       if address_str.ends_with('/') && specifier_str.starts_with(&address_str) {
-        return Some(specifier_str.replace(&address_str, &key));
+        return Some(specifier_str.replace(&address_str, key));
       }
     }
   }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -316,7 +316,7 @@ fn lookup_imports() {
     }
   }"#;
   let result = parse_from_json(
-    &Url::parse("file:///a/import-map.json").unwrap(),
+    &Url::parse("file://C:/a/import-map.json").unwrap(),
     json_map,
   );
   assert!(result.is_ok());
@@ -325,7 +325,7 @@ fn lookup_imports() {
     import_map,
   } = result.unwrap();
   assert!(diagnostics.is_empty());
-  let referrer = Url::parse("file:///a/a.ts").unwrap();
+  let referrer = Url::parse("file://C:/a/a.ts").unwrap();
   let specifier_a =
     Url::parse("https://deno.land/x/std@0.147.0/node/fs.ts").unwrap();
   let result = import_map.lookup(&specifier_a, &referrer);
@@ -333,7 +333,7 @@ fn lookup_imports() {
   let specifier_b = Url::parse("https://deno.land/x/mod@1.0.0/lib.ts").unwrap();
   let result = import_map.lookup(&specifier_b, &referrer);
   assert_eq!(result, Some("mod/lib.ts".to_string()));
-  let specifier_c = Url::parse("file:///std/testing/asserts.ts").unwrap();
+  let specifier_c = Url::parse("file://C:/std/testing/asserts.ts").unwrap();
   let result = import_map.lookup(&specifier_c, &referrer);
   assert_eq!(result, Some("/~/testing/asserts.ts".to_string()));
 }


### PR DESCRIPTION
The lookup API was using the stored key, which when the there is a leading `/` it stores the key as relative to the base url.  Previous versions incorrectly tried to strip just `file://` from the key which breaks on windows.  This now uses the `raw_url` of the value which should provide correct output in every scenario.