### PR TITLE
feat: Add expand_imports API

### DIFF
--- a/rs-lib/src/ext.rs
+++ b/rs-lib/src/ext.rs
@@ -28,25 +28,25 @@ pub fn expand_imports(import_map: ImportMapConfig) -> Value {
           continue;
         };
 
-        if (value_str.starts_with("jsr:") || value_str.starts_with("npm:"))
-          && !value_str.ends_with('/')
-        {
+        if !value_str.ends_with('/') {
           let value_with_trailing_slash =
             if let Some(value_str) = value_str.strip_prefix("jsr:") {
               let value_str = value_str.strip_prefix('/').unwrap_or(value_str);
-              format!("jsr:/{}/", value_str)
-            } else {
-              let value_str = value_str.strip_prefix("npm:").unwrap();
+              Some(format!("jsr:/{}/", value_str))
+            } else if let Some(value_str) = value_str.strip_prefix("npm:") {
               let value_str = value_str.strip_prefix('/').unwrap_or(value_str);
-              format!("npm:/{}/", value_str)
+              Some(format!("npm:/{}/", value_str))
+            } else {
+              None
             };
 
-          expanded_imports.insert(
-            key_with_trailing_slash,
-            Value::String(value_with_trailing_slash),
-          );
-
-          continue;
+          if let Some(value_with_trailing_slash) = value_with_trailing_slash {
+            expanded_imports.insert(
+              key_with_trailing_slash,
+              Value::String(value_with_trailing_slash),
+            );
+            continue;
+          }
         }
       }
 

--- a/rs-lib/src/ext.rs
+++ b/rs-lib/src/ext.rs
@@ -4,6 +4,13 @@ use serde_json::json;
 use serde_json::Value;
 use url::Url;
 
+/// This function can be used to modify the `import` mapping to expand
+/// bare specifier imports to provide "directory" imports, eg.:
+/// - `"express": "npm:express@4` -> `"express/": "npm:/express@4/`
+/// - `"@std": "jsr:@std` -> `"std@/": "jsr:/@std/`
+///
+/// Only `npm:` and `jsr:` scheme are expanded and if there's already a
+/// "directory" import, it is not overwritten.
 pub fn expand_imports(import_map: ImportMapConfig) -> Value {
   let mut expanded_imports = serde_json::Map::new();
 

--- a/rs-lib/src/ext.rs
+++ b/rs-lib/src/ext.rs
@@ -33,11 +33,11 @@ pub fn expand_imports(import_map: ImportMapConfig) -> Value {
         {
           let value_with_trailing_slash =
             if let Some(value_str) = value_str.strip_prefix("jsr:") {
-              let value_str = value_str.strip_prefix("/").unwrap_or(value_str);
+              let value_str = value_str.strip_prefix('/').unwrap_or(value_str);
               format!("jsr:/{}/", value_str)
             } else {
               let value_str = value_str.strip_prefix("npm:").unwrap();
-              let value_str = value_str.strip_prefix("/").unwrap_or(value_str);
+              let value_str = value_str.strip_prefix('/').unwrap_or(value_str);
               format!("npm:/{}/", value_str)
             };
 

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright 2021-2023 the Deno authors. All rights reserved. MIT license.
 
-use ext::ImportMapConfig;
 use indexmap::IndexMap;
 use serde_json::Map;
 use serde_json::Value;
@@ -538,6 +537,8 @@ impl ImportMap {
   /// "directory" import, it is not overwritten.
   #[cfg(feature = "ext")]
   pub fn ext_expand_imports(&mut self) {
+    use ext::ImportMapConfig;
+    
     let json_str = self.to_json();
     let json_value = serde_json::from_str(&json_str).unwrap();
     let expanded_imports = ext::expand_imports(ImportMapConfig {

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -538,7 +538,7 @@ impl ImportMap {
   #[cfg(feature = "ext")]
   pub fn ext_expand_imports(&mut self) {
     use ext::ImportMapConfig;
-    
+
     let json_str = self.to_json();
     let json_value = serde_json::from_str(&json_str).unwrap();
     let expanded_imports = ext::expand_imports(ImportMapConfig {


### PR DESCRIPTION
This adds `ext::expand_imports` API which can take an import map configuration
and expands its `imports` to automatically remaps with trailing slashes for bare
specifiers.