### PR TITLE
fix: uptake latest version of publish_release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           git config user.email "denobot@users.noreply.github.com"
           git config user.name "denobot"
-          deno run -A https://raw.githubusercontent.com/denoland/automation/0.14.2/tasks/publish_release.ts --${{github.event.inputs.releaseKind}} import_map
+          deno run -A https://raw.githubusercontent.com/denoland/automation/0.20.1/tasks/publish_release.ts --${{github.event.inputs.releaseKind}} import_map


### PR DESCRIPTION
closes https://github.com/denoland/import_map/issues/60

See the following for context:
* https://github.com/denoland/import_map/issues/60#issuecomment-1911772240
* https://github.com/denoland/automation/pull/42

@dsherret, I guess I'll need a new tag for `automation` published after the above PR is merged, since `0.20.1` doesn't currently exist.