### PR TITLE
fix: handle non-file scopes in synthetic import map

### DIFF
--- a/rs-lib/src/ext.rs
+++ b/rs-lib/src/ext.rs
@@ -124,7 +124,7 @@ pub fn create_synthetic_import_map(
         // prepend the member name to the scope.
         let Ok(scope_name_dir) = member_dir.join(scope_name) else {
           synth_import_map_scopes.insert(scope_name.clone(), scope_obj.clone());
-          continue; // ignore
+          continue; // not a file specifier
         };
         let Some(relative_to_base_dir) =
           base_import_map_dir.make_relative(&scope_name_dir)


### PR DESCRIPTION
Adds the scopes for remote specifiers to the synthetic import map.

For https://github.com/denoland/deno/issues/22353