### PR TITLE
refactor: take an owned URL in parse_from_value

### DIFF
--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -610,14 +610,14 @@ pub fn parse_from_json_with_options(
 }
 
 pub fn parse_from_value(
-  base_url: &Url,
+  base_url: Url,
   json_value: Value,
 ) -> Result<ImportMapWithDiagnostics, ImportMapError> {
   parse_from_value_with_options(base_url, json_value, Default::default())
 }
 
 pub fn parse_from_value_with_options(
-  base_url: &Url,
+  base_url: Url,
   json_value: Value,
   options: ImportMapOptions,
 ) -> Result<ImportMapWithDiagnostics, ImportMapError> {
@@ -625,13 +625,13 @@ pub fn parse_from_value_with_options(
   let (unresolved_imports, unresolved_scopes) =
     parse_value(json_value, &options, &mut diagnostics)?;
   let imports =
-    parse_specifier_map(unresolved_imports, base_url, &mut diagnostics);
-  let scopes = parse_scope_map(unresolved_scopes, base_url, &mut diagnostics)?;
+    parse_specifier_map(unresolved_imports, &base_url, &mut diagnostics);
+  let scopes = parse_scope_map(unresolved_scopes, &base_url, &mut diagnostics)?;
 
   Ok(ImportMapWithDiagnostics {
     diagnostics,
     import_map: ImportMap {
-      base_url: base_url.clone(),
+      base_url,
       imports,
       scopes,
     },

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -680,7 +680,7 @@ pub fn outputs_import_map_as_json_imports_and_scopes() {
 #[test]
 fn parse_with_address_hook() {
   let result = parse_from_value_with_options(
-    &Url::parse("file:///").unwrap(),
+    Url::parse("file:///").unwrap(),
     json!({
       "imports": {
         "preact": "npm:preact",


### PR DESCRIPTION
This function always clones the value, so it's better to take an owned value upfront in order to reduce cloning overall.