### PR TITLE
refactor: `parse_from_json` - take an owned url

### DIFF
--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -582,14 +582,14 @@ impl ImportMap {
 }
 
 pub fn parse_from_json(
-  base_url: &Url,
+  base_url: Url,
   json_string: &str,
 ) -> Result<ImportMapWithDiagnostics, ImportMapError> {
   parse_from_json_with_options(base_url, json_string, Default::default())
 }
 
 pub fn parse_from_json_with_options(
-  base_url: &Url,
+  base_url: Url,
   json_string: &str,
   options: ImportMapOptions,
 ) -> Result<ImportMapWithDiagnostics, ImportMapError> {
@@ -597,13 +597,13 @@ pub fn parse_from_json_with_options(
   let (unresolved_imports, unresolved_scopes) =
     parse_json(json_string, &options, &mut diagnostics)?;
   let imports =
-    parse_specifier_map(unresolved_imports, base_url, &mut diagnostics);
-  let scopes = parse_scope_map(unresolved_scopes, base_url, &mut diagnostics)?;
+    parse_specifier_map(unresolved_imports, &base_url, &mut diagnostics);
+  let scopes = parse_scope_map(unresolved_scopes, &base_url, &mut diagnostics)?;
 
   Ok(ImportMapWithDiagnostics {
     diagnostics,
     import_map: ImportMap {
-      base_url: base_url.clone(),
+      base_url,
       imports,
       scopes,
     },
@@ -1279,7 +1279,7 @@ mod test {
     }
   }
 }"#;
-    let im = parse_from_json(&url, json_string).unwrap();
+    let im = parse_from_json(url, json_string).unwrap();
     let im = im.import_map;
     let keys = im
       .entries_for_referrer(&Url::parse("file:///folder/main.ts").unwrap())

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -1227,7 +1227,7 @@ mod test {
   }
 }"#;
     let im = parse_from_json_with_options(
-      &url,
+      url,
       json_string,
       ImportMapOptions {
         address_hook: None,

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -360,10 +360,8 @@ fn lookup_scopes() {
       }
     }
   }"#;
-  let result = parse_from_json(
-    Url::parse("file:///a/import-map.json").unwrap(),
-    json_map,
-  );
+  let result =
+    parse_from_json(Url::parse("file:///a/import-map.json").unwrap(), json_map);
   assert!(result.is_ok());
   let ImportMapWithDiagnostics {
     diagnostics,

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -188,7 +188,7 @@ fn run_import_map_test_cases(tests: Vec<ImportMapTestCase>) {
         base_url,
       } => {
         let import_map =
-          parse_from_json(&test.import_map_base_url, &test.import_map)
+          parse_from_json(test.import_map_base_url, &test.import_map)
             .unwrap()
             .import_map;
         let maybe_resolved = import_map
@@ -201,11 +201,11 @@ fn run_import_map_test_cases(tests: Vec<ImportMapTestCase>) {
         expected_import_map,
       } => {
         if matches!(expected_import_map, Value::Null) {
-          assert!(parse_from_json(&test.import_map_base_url, &test.import_map)
+          assert!(parse_from_json(test.import_map_base_url, &test.import_map)
             .is_err());
         } else {
           let import_map =
-            parse_from_json(&test.import_map_base_url, &test.import_map)
+            parse_from_json(test.import_map_base_url, &test.import_map)
               .unwrap()
               .import_map;
           let import_map_value = serde_json::to_value(import_map).unwrap();
@@ -232,18 +232,18 @@ fn from_json_1() {
   let base_url = Url::parse("https://deno.land").unwrap();
 
   // empty JSON
-  assert!(parse_from_json(&base_url, "{}").is_ok());
+  assert!(parse_from_json(base_url.clone(), "{}").is_ok());
 
   let non_object_strings = vec!["null", "true", "1", "\"foo\"", "[]"];
 
   // invalid JSON
   for non_object in non_object_strings.iter().copied() {
-    assert!(parse_from_json(&base_url, non_object).is_err());
+    assert!(parse_from_json(base_url.clone(), non_object).is_err());
   }
 
   // invalid JSON message test
   assert_eq!(
-    parse_from_json(&base_url, "{\"a\":1,}")
+    parse_from_json(base_url.clone(), "{\"a\":1,}")
       .unwrap_err()
       .to_string(),
     "Unable to parse import map JSON: trailing comma at line 1 column 8",
@@ -252,7 +252,7 @@ fn from_json_1() {
   // invalid schema: 'imports' is non-object
   for non_object in non_object_strings.iter() {
     assert!(parse_from_json(
-      &base_url,
+      base_url.clone(),
       &format!("{{\"imports\": {}}}", non_object),
     )
     .is_err());
@@ -261,7 +261,7 @@ fn from_json_1() {
   // invalid schema: 'scopes' is non-object
   for non_object in non_object_strings {
     assert!(parse_from_json(
-      &base_url,
+      base_url.clone(),
       &format!("{{\"scopes\": {}}}", non_object),
     )
     .is_err());
@@ -278,7 +278,7 @@ fn from_json_2() {
     }
   }"#;
   let result =
-    parse_from_json(&Url::parse("https://deno.land").unwrap(), json_map);
+    parse_from_json(Url::parse("https://deno.land").unwrap(), json_map);
   assert!(result.is_ok());
   let diagnostics = result.unwrap().diagnostics;
   assert_eq!(diagnostics.len(), 2);
@@ -297,7 +297,7 @@ fn from_json_3() {
     }
   }"#;
   let result =
-    parse_from_json(&Url::parse("https://deno.land").unwrap(), json_map);
+    parse_from_json(Url::parse("https://deno.land").unwrap(), json_map);
   assert!(result.is_ok());
   let diagnostics = result.unwrap().diagnostics;
   assert_eq!(diagnostics.len(), 3);
@@ -322,7 +322,7 @@ fn lookup_imports() {
     }
   }"#;
   let result = parse_from_json(
-    &Url::parse("file://C:/a/import-map.json").unwrap(),
+    Url::parse("file://C:/a/import-map.json").unwrap(),
     json_map,
   );
   assert!(result.is_ok());
@@ -361,7 +361,7 @@ fn lookup_scopes() {
     }
   }"#;
   let result = parse_from_json(
-    &Url::parse("file:///a/import-map.json").unwrap(),
+    Url::parse("file:///a/import-map.json").unwrap(),
     json_map,
   );
   assert!(result.is_ok());
@@ -394,7 +394,7 @@ fn invalid_top_level_key() {
     }
   }"#;
   let result =
-    parse_from_json(&Url::parse("https://deno.land").unwrap(), json_map);
+    parse_from_json(Url::parse("https://deno.land").unwrap(), json_map);
   assert!(result.is_ok());
   let diagnostics = result.unwrap().diagnostics;
   assert_eq!(diagnostics.len(), 1);
@@ -414,7 +414,7 @@ fn invalid_scope() {
     }
   }"#;
   let result =
-    parse_from_json(&Url::parse("https://deno.land").unwrap(), json_map);
+    parse_from_json(Url::parse("https://deno.land").unwrap(), json_map);
   assert!(result.is_ok());
   let diagnostics = result.unwrap().diagnostics;
   assert_eq!(diagnostics.len(), 1);
@@ -429,7 +429,7 @@ fn querystring() {
     }
   }"#;
   let import_map =
-    parse_from_json(&Url::parse("https://deno.land").unwrap(), json_map)
+    parse_from_json(Url::parse("https://deno.land").unwrap(), json_map)
       .unwrap()
       .import_map;
 
@@ -480,7 +480,7 @@ fn append_imports() {
     }
   }"#;
   let mut import_map =
-    parse_from_json(&Url::parse("https://deno.land").unwrap(), json_map)
+    parse_from_json(Url::parse("https://deno.land").unwrap(), json_map)
       .unwrap()
       .import_map;
   import_map
@@ -549,7 +549,7 @@ fn append_imports() {
 #[test]
 fn get_or_append_scope_mut() {
   let mut import_map =
-    parse_from_json(&Url::parse("https://deno.land").unwrap(), "{}")
+    parse_from_json(Url::parse("https://deno.land").unwrap(), "{}")
       .unwrap()
       .import_map;
 
@@ -596,7 +596,7 @@ fn import_keys() {
     }
   }"#;
   let import_map =
-    parse_from_json(&Url::parse("https://deno.land").unwrap(), json_map)
+    parse_from_json(Url::parse("https://deno.land").unwrap(), json_map)
       .unwrap()
       .import_map;
   assert_eq!(
@@ -610,7 +610,7 @@ pub fn outputs_import_map_as_json_empty() {
   let json = r#"{
 }
 "#;
-  let import_map = parse_from_json(&Url::parse("file:///dir/").unwrap(), json)
+  let import_map = parse_from_json(Url::parse("file:///dir/").unwrap(), json)
     .unwrap()
     .import_map;
   assert_eq!(import_map.to_json(), json);
@@ -624,7 +624,7 @@ pub fn outputs_import_map_as_json_imports_only() {
   }
 }
 "#;
-  let import_map = parse_from_json(&Url::parse("file:///dir/").unwrap(), json)
+  let import_map = parse_from_json(Url::parse("file:///dir/").unwrap(), json)
     .unwrap()
     .import_map;
   assert_eq!(import_map.to_json(), json);
@@ -641,7 +641,7 @@ pub fn outputs_import_map_as_json_scopes_only() {
   }
 }
 "#;
-  let import_map = parse_from_json(&Url::parse("file:///dir/").unwrap(), json)
+  let import_map = parse_from_json(Url::parse("file:///dir/").unwrap(), json)
     .unwrap()
     .import_map;
   assert_eq!(import_map.to_json(), json);
@@ -671,7 +671,7 @@ pub fn outputs_import_map_as_json_imports_and_scopes() {
   }
 }
 "#;
-  let import_map = parse_from_json(&Url::parse("file:///dir/").unwrap(), json)
+  let import_map = parse_from_json(Url::parse("file:///dir/").unwrap(), json)
     .unwrap()
     .import_map;
   assert_eq!(import_map.to_json(), json);
@@ -719,7 +719,7 @@ fn parse_with_address_hook() {
 #[test]
 fn parse_with_no_double_encode() {
   let result = parse_from_json(
-    &Url::parse("file:///").unwrap(),
+    Url::parse("file:///").unwrap(),
     &json!({
       "imports": {
         "./": "./"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -37,7 +37,7 @@ pub fn js_parse_from_json(
 ) -> Result<JsImportMap, JsError> {
   let base_url =
     Url::parse(&base_url).map_err(|err| JsError::new(&err.to_string()))?;
-  parse_from_json(&base_url, &json_string)
+  parse_from_json(base_url, &json_string)
     .map(|map_with_diag| JsImportMap(map_with_diag.import_map))
     .map_err(|err| JsError::new(&err.to_string()))
 }


### PR DESCRIPTION
This clones the value so the caller should provide an owned value to reduce clones.