### PR TITLE
feat: new error message for unmapped deps

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 the Deno authors. All rights reserved. MIT license.
+# Copyright 2020-2025 the Deno authors. All rights reserved. MIT license.
 max_width = 80
 tab_spaces = 2
 edition = "2021"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2024 the Deno authors
+Copyright (c) 2018-2025 the Deno authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "lock": false,
   "tasks": {
     "test": "deno test --allow-read",
-    "build": "cp LICENSE js/LICENSE && deno run -A --unstable https://deno.land/x/wasmbuild@0.15.1/main.ts --out js"
+    "build": "cp LICENSE js/LICENSE && deno run -A https://deno.land/x/wasmbuild@0.15.1/main.ts --out js"
   },
   "exclude": ["target", "wpt", "temp"]
 }

--- a/js/mod.ts
+++ b/js/mod.ts
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 the Deno authors. All rights reserved. MIT license.
+// Copyright 2021-2025 the Deno authors. All rights reserved. MIT license.
 
 /**
  * Provides a [spec compliant](https://wicg.github.io/import-maps/)

--- a/rs-lib/src/ext.rs
+++ b/rs-lib/src/ext.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2025 the Deno authors. All rights reserved. MIT license.
 
 use serde_json::json;
 use serde_json::Value;

--- a/rs-lib/src/lib.rs
+++ b/rs-lib/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2025 the Deno authors. All rights reserved. MIT license.
 
 use indexmap::IndexMap;
 use serde_json::Map;
@@ -69,7 +69,7 @@ pub struct ImportMapError(pub Box<ImportMapErrorKind>);
 #[class(type)]
 pub enum ImportMapErrorKind {
   #[error(
-    "Relative import path \"{}\" not prefixed with / or ./ or ../ and not in import map{}",
+    "Import \"{}\" not a dependency and not in import map{}",
     .0,
     .1.as_ref().map(|referrer| format!(" from \"{}\"", referrer)).unwrap_or_default(),
   )]

--- a/rs-lib/src/specifier.rs
+++ b/rs-lib/src/specifier.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2024 the Deno authors. MIT license.
+// Copyright 2018-2025 the Deno authors. MIT license.
 
 use thiserror::Error;
 use url::Url;
@@ -12,7 +12,7 @@ pub enum SpecifierError {
   InvalidUrl(url::ParseError),
   #[class(type)]
   #[error(
-    "Relative import path \"{specifier}\" not prefixed with / or ./ or ../"
+    "Import \"{specifier}\" not a dependency"
   )]
   ImportPrefixMissing {
     specifier: String,

--- a/rs-lib/tests/integration_test.rs
+++ b/rs-lib/tests/integration_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2025 the Deno authors. All rights reserved. MIT license.
 
 use import_map::parse_from_json;
 use import_map::parse_from_value_with_options;

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,9 +1,10 @@
-// Copyright 2021-2023 the Deno authors. All rights reserved. MIT license.
+// Copyright 2021-2025 the Deno authors. All rights reserved. MIT license.
 
 import {
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.205.0/assert/mod.ts";
+  // deno-lint-ignore no-import-prefix
+} from "jsr:@std/assert@1.0.14";
 import { parseFromJson } from "../js/mod.ts";
 
 Deno.test({
@@ -26,7 +27,7 @@ Deno.test({
         importMap.resolve("notfound", "https://deno.land/x/oak/mod.ts");
       },
       Error,
-      "Relative import path",
+      "not a dependency",
     );
   },
 });
@@ -51,7 +52,7 @@ Deno.test({
         importMap.resolve("notfound", "https://deno.land/x/oak/mod.ts");
       },
       Error,
-      "Relative import path",
+      "not a dependency",
     );
   },
 });
@@ -78,7 +79,7 @@ Deno.test({
         importMap.resolve("@std/assert/test", "https://deno.land/x/oak/mod.ts");
       },
       Error,
-      "Relative import path",
+      "not a dependency",
     );
   },
 });

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2025 the Deno authors. All rights reserved. MIT license.
 
 use import_map::{parse_from_json_with_options, ImportMap, ImportMapOptions};
 use url::Url;


### PR DESCRIPTION
```diff
+ error: Import "foo" not a dependency
- error: Relative import path "foo" not prefixed with / or ./ or ../

+ error: Import "foo" not a dependency and not in import map
- error: Relative import path "foo" not prefixed with / or ./ or ../ and not in import map
```